### PR TITLE
No Voting on One's Own Proposed Rules

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -20,7 +20,7 @@ In cases where rules are accepted at the same time, the decision will be based o
 
 ## 3 - Rule Acceptance
 A rule must be accepted by vote before it is passed into effect. A rule passes if it receives 3 votes in its favour. A rule cannot pass if there are 3 votes against it.
-Players cast their votes by commenting on open Pull Requests. 
+Players cast their votes by commenting on open Pull Requests. Players cannot cast votes for rules they've proposed.
 
 ## 4 - Citizenship Rights
 A player cannot propose a new rule if there are any outstanding proposals they have not personally cast a vote on. They must check the open Pull Requests and cast votes. If the number of votes required to pass or reject a rule have already been cast, they do not need to vote.


### PR DESCRIPTION
I'd like to see at least three other people approve a rule before it's accepted rather than only two other people plus oneself. I think there's enough of us playing at this point where this makes sense.

Specifically, I added the following text in **bold** to the end of Rule #3:

> Players cast their votes by commenting on open Pull Requests. **Players cannot cast votes for rules they've proposed.**

I wasn't sure how to word this, so suggestions are welcome.