### PR TITLE
Rule to post on fCC Forum when proposing a new rule

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -33,3 +33,10 @@ The number of stickers will be tracked on the wiki.
 ## 6 - Bugs in Your Code
 If a rule is rejected, the player that proposed the rule will have gained a software bug!
 Bugs are tracked on the wiki.
+
+## 7 - Include fCC Forum
+Once a new rule has been proposed, the player proposing the new rule will add a reply to the [freeCodeCamp forum topic](https://www.freecodecamp.org/forum/t/learn-github-pull-requests-by-playing-a-game-with-other-campers/238897) that includes the following:
+
+  - Rule Name
+  - Description of the Rule
+  - Link to GitHub Pull Request


### PR DESCRIPTION
This rule has two main objectives:

1. Notify as many other players as possible about the newly proposed rule. Some people may get notified of forum replies faster and more often than email (or other) notifications from GitHub.

2. Keep the fCC forum community aware of the game so newer members will know they can join. A steady stream of forum topic replies will keep the forum topic visible to more people.

Specifically, the following text was added to **RULES.md**:

> ## 7 - Include fCC Forum
> Once a new rule has been proposed, the player proposing the new rule will add a reply to the [freeCodeCamp forum topic](https://www.freecodecamp.org/forum/t/learn-github-pull-requests-by-playing-a-game-with-other-campers/238897) that includes the following:
> 
>  - Rule Name
>  - Description of the Rule
>  - Link to GitHub Pull Request
