### PR TITLE
Make voting process clearer

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -1,42 +1,52 @@
 # Universal Constants
 
 ## UC1 - Rule Proposal via Pull Request Only
+
 Rules can only be proposed as changes to this file (RULES.md) via Github Pull Requests. This file (RULES.md) is the single source of truth for rules in this game.
 
 ## UC2 - Code of Conduct
+
 A rule, a proposal, action, or any discussion taking place relating to this game in any forum or channel must abide by the freeCodeCamp [Code of Conduct](https://freecodecamp.org/code-of-conduct).
 Code of Conduct violations should be reported to the repository maintainer, or any other agent later empowered by subsequent rule changes, and their judgement and enacted consequences will be final.
 
 # Rules
 
 ## 1 - Rule Formatting
+
 A rule shall be formatted according to the example demonstrated by this rule. That is, a short title is provided, using a `##` level header which includes the proposed rule number.
 A longer description of the scope and effects of the rule shall be included underneath.
 
 ## 2 - Rule Numbering
-A rule should be numbered sequentially according to the last accepted rule. 
+
+A rule should be numbered sequentially according to the last accepted rule.
 In the case were multiple rules are proposed that share the same propsed rule number, the maintainer, or any other agent later empowered by subsequent rule changes, will manually amend the rule numbers when merging pull requests, according to the order in which the rules were accepted.
 In cases where rules are accepted at the same time, the decision will be based on when the rule was proposed.
 
 ## 3 - Rule Acceptance
+
 A rule must be accepted by vote before it is passed into effect. A rule passes if it receives 3 votes in its favour. A rule cannot pass if there are 3 votes against it.
-Players cast their votes by commenting on open Pull Requests. 
+Players cast their votes by reacting with a `+1` or a `-1` to the pull request message.
 
 ## 4 - Citizenship Rights
+
 A player cannot propose a new rule if there are any outstanding proposals they have not personally cast a vote on. They must check the open Pull Requests and cast votes. If the number of votes required to pass or reject a rule have already been cast, they do not need to vote.
 
 ## 5 - Stickers
+
 If a rule is accepted, the player that proposed it will be awarded a 3x3cm hexagonal laptop sticker.
 The number of stickers will be tracked on the wiki.
 (The stickers exist in-game only, unfortunately)
 
 ## 6 - Bugs in Your Code
+
 If a rule is rejected, the player that proposed the rule will have gained a software bug!
 Bugs are tracked on the wiki.
 
 ## 7 - Rule-Changes and New Rules
+
 The adoption of new rules and rule-changes must never become completely impermissible.
 
 ## 8 - Dub Thee 'Hunter of Bugs'
+
 Any player that raises a valid issue relating to the repo, such as typos, or improvements to the CONTRIBUTING.md, will receive the Title 'Hunter of Bugs'.
 This rule applies retroactively.

--- a/RULES.md
+++ b/RULES.md
@@ -25,7 +25,7 @@ In cases where rules are accepted at the same time, the decision will be based o
 ## 3 - Rule Acceptance
 
 A rule must be accepted by vote before it is passed into effect. A rule passes if it receives 3 votes in its favour. A rule cannot pass if there are 3 votes against it.
-Players cast their votes by reacting with a `+1` or a `-1` to the pull request message.
+Players cast their votes by reacting with a `+1` or a `-1` to the pull request message. Additionally, the player has to add a comment indicating that they have voted.
 
 ## 4 - Citizenship Rights
 

--- a/RULES.md
+++ b/RULES.md
@@ -1,52 +1,42 @@
 # Universal Constants
 
 ## UC1 - Rule Proposal via Pull Request Only
-
 Rules can only be proposed as changes to this file (RULES.md) via Github Pull Requests. This file (RULES.md) is the single source of truth for rules in this game.
 
 ## UC2 - Code of Conduct
-
 A rule, a proposal, action, or any discussion taking place relating to this game in any forum or channel must abide by the freeCodeCamp [Code of Conduct](https://freecodecamp.org/code-of-conduct).
 Code of Conduct violations should be reported to the repository maintainer, or any other agent later empowered by subsequent rule changes, and their judgement and enacted consequences will be final.
 
 # Rules
 
 ## 1 - Rule Formatting
-
 A rule shall be formatted according to the example demonstrated by this rule. That is, a short title is provided, using a `##` level header which includes the proposed rule number.
 A longer description of the scope and effects of the rule shall be included underneath.
 
 ## 2 - Rule Numbering
-
 A rule should be numbered sequentially according to the last accepted rule.
 In the case were multiple rules are proposed that share the same propsed rule number, the maintainer, or any other agent later empowered by subsequent rule changes, will manually amend the rule numbers when merging pull requests, according to the order in which the rules were accepted.
 In cases where rules are accepted at the same time, the decision will be based on when the rule was proposed.
 
 ## 3 - Rule Acceptance
-
 A rule must be accepted by vote before it is passed into effect. A rule passes if it receives 3 votes in its favour. A rule cannot pass if there are 3 votes against it.
 Players cast their votes by reacting with a `+1` or a `-1` to the pull request message. Additionally, the player has to add a comment indicating that they have voted.
 
 ## 4 - Citizenship Rights
-
 A player cannot propose a new rule if there are any outstanding proposals they have not personally cast a vote on. They must check the open Pull Requests and cast votes. If the number of votes required to pass or reject a rule have already been cast, they do not need to vote.
 
 ## 5 - Stickers
-
 If a rule is accepted, the player that proposed it will be awarded a 3x3cm hexagonal laptop sticker.
 The number of stickers will be tracked on the wiki.
 (The stickers exist in-game only, unfortunately)
 
 ## 6 - Bugs in Your Code
-
 If a rule is rejected, the player that proposed the rule will have gained a software bug!
 Bugs are tracked on the wiki.
 
 ## 7 - Rule-Changes and New Rules
-
 The adoption of new rules and rule-changes must never become completely impermissible.
 
 ## 8 - Dub Thee 'Hunter of Bugs'
-
 Any player that raises a valid issue relating to the repo, such as typos, or improvements to the CONTRIBUTING.md, will receive the Title 'Hunter of Bugs'.
 This rule applies retroactively.


### PR DESCRIPTION
Proposed is the following change to `rule #3`:

> Players cast their votes by reacting with a `+1` or a `-1` to the pull request message.

If official voting can only be done by reacting with a `+1` or `-1` to the pull request message, everyone can directly see the current votes without having to go through all the comments.