### PR TITLE
Rule 10 - Proposals

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -14,7 +14,7 @@ A rule shall be formatted according to the example demonstrated by this rule. Th
 A longer description of the scope and effects of the rule shall be included underneath.
 
 ## 2 - Rule Numbering
-A rule should be numbered sequentially according to the last accepted rule. 
+A rule should be numbered sequentially according to the last accepted rule.
 In the case were multiple rules are proposed that share the same propsed rule number, the maintainer, or any other agent later empowered by subsequent rule changes, will manually amend the rule numbers when merging pull requests, according to the order in which the rules were accepted.
 In cases where rules are accepted at the same time, the decision will be based on when the rule was proposed.
 
@@ -42,6 +42,10 @@ Any player that raises a valid issue relating to the repo, such as typos, or imp
 This rule applies retroactively.
 
 ## 9 - Squish Bugs
-If a player has accumalated bugs in their software, they can pay another player with the title 'Hunter of Bugs' to remove the bug for them at a cost of ONE sticker which will be paid directly to the 'Hunter of Bugs'. 
+If a player has accumalated bugs in their software, they can pay another player with the title 'Hunter of Bugs' to remove the bug for them at a cost of ONE sticker which will be paid directly to the 'Hunter of Bugs'.
 Players will discuss their transactions in a newly created 'Market Place' issues thread.
 A player cannot remove their own bugs, even if they are also a 'Hunter of Bugs'.
+
+## 10 - Proposals
+By submitting a Github Pull Request, players may propose any change to this ruleset, including the addition of new rules as well as the amendment or removal of existing rules.
+All such proposals are subject to the same rules as new rules proposals. In particular, a proposal must be accepted by vote, as described in rule 3 - Rule Acceptance, before it is passed into effect; and players cannot make a new proposal if there is any outstanding proposals they have not personally cast a vote on, as described in rule 4 - Citizenship Rights.

--- a/RULES.md
+++ b/RULES.md
@@ -47,5 +47,5 @@ Players will discuss their transactions in a newly created 'Market Place' issues
 A player cannot remove their own bugs, even if they are also a 'Hunter of Bugs'.
 
 ## 10 - Proposals
-By submitting a Github Pull Request, players may propose any change to this ruleset, including the addition of new rules as well as the amendment or removal of existing rules.
+By submitting a Github Pull Request, players may propose any change to this ruleset, including the addition of one or more new rules, as well as the amendment or removal of one or more existing rules.
 All such proposals are subject to the same rules as new rules proposals. In particular, a proposal must be accepted by vote, as described in rule 3 - Rule Acceptance, before it is passed into effect; and players cannot make a new proposal if there is any outstanding proposals they have not personally cast a vote on, as described in rule 4 - Citizenship Rights.


### PR DESCRIPTION
Add new rule:

## 10 - Proposals
By submitting a Github Pull Request, players may propose any change to this ruleset, including the addition of new rules as well as the amendment or removal of existing rules.
All such proposals are subject to the same rules as new rules proposals. In particular, a proposal must be accepted by vote, as described in rule 3 - Rule Acceptance, before it is passed into effect; and players cannot make a new proposal if there is any outstanding proposals they have not personally cast a vote on, as described in rule 4 - Citizenship Rights.
